### PR TITLE
Service Id fixes

### DIFF
--- a/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
+++ b/Huxley2/Connected Services/OpenLDBWS/BaseServiceItem.cs
@@ -20,14 +20,10 @@ namespace OpenLDBWS
 
         public Guid ServiceIdGuid => ToGuid(serviceIDField);
 
-        // note that while ServiceID is already URL-safe, the underscore char
-        // is not valid base64, so any inputs that previously assumed b64 input
-        // may break. As such, we will encode the string to be b64-safe as well
-        // as URL-safe
+        // the Base64 encoding seems to break the recognisable serviceID on the NRE server
+        // so just send it as is
         [SuppressMessage("Design", "CA1056:Uri properties should not be strings", Justification = "Not a URL")]
-        public string ServiceIdUrlSafe => WebEncoders.Base64UrlEncode(
-            System.Text.Encoding.UTF8.GetBytes(serviceIDField)
-        );
+        public string ServiceIdUrlSafe => serviceID;
 
         public static Guid ToGuid(string serviceID)
         {

--- a/Huxley2/Services/ServiceDetailsService.cs
+++ b/Huxley2/Services/ServiceDetailsService.cs
@@ -77,18 +77,12 @@ namespace Huxley2.Services
                 }
             }
 
-            if (request.ServiceId.Length == 15)
-            {
-                _logger.LogInformation($"Calling service details SOAP endpoint for {request.ServiceId}");
-                var service = await _soapClient.GetServiceDetailsAsync(new GetServiceDetailsRequest
-                {
-                    AccessToken = _accessTokenService.MakeAccessToken(request),
-                    serviceID = request.ServiceId,
-                });
-                return service.GetServiceDetailsResult;
-            }
-
-            throw new Exception("Invalid Service ID provided");
+            _logger.LogInformation($"Calling service details SOAP endpoint for {request.ServiceId}");
+            var service = await _soapClient.GetServiceDetailsAsync(new GetServiceDetailsRequest {
+                AccessToken = _accessTokenService.MakeAccessToken(request),
+                serviceID = request.ServiceId,
+            });
+            return service.GetServiceDetailsResult;
         }
 
         public string GenerateChecksum(object service) => ChecksumGenerator.GenerateChecksum(service);

--- a/Huxley2/docker-compose.yml
+++ b/Huxley2/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.9"
 services:
   huxley2:
+    # restart: always
     build: .
     environment:
       - DarwinAccessToken=${ACCESS_TOKEN}

--- a/Huxley2Tests/OpenLDBWS/BaseServiceItemTests.cs
+++ b/Huxley2Tests/OpenLDBWS/BaseServiceItemTests.cs
@@ -48,9 +48,7 @@ namespace Huxley2Tests.OpenLDBWS
             {
                 serviceID = code
             };
-            var expected = WebEncoders.Base64UrlEncode(
-                System.Text.Encoding.UTF8.GetBytes(code)
-            );
+            var expected = serviceItem.serviceID;
             Assert.Equal(expected, serviceItem.ServiceIdUrlSafe);
         }
     }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ CLIENT_ACCESS_TOKEN=abcde12345
 
 To rebuild use `docker-compose build` or `docker-compose up --build`.
 
+If you want to run the container in the background you can run `docker-compose up --detach`
+
+If you would like the docker container to _reboot upon restart_ on the host machine you can uncomment `restart: always` in the docker-compose.yml file and make sure the docker service is set to start upon bootup. 
+
 ## Station Codes File
 
 If you need to regenerate [the station codes CSV file in this repo](https://raw.githubusercontent.com/jpsingleton/Huxley2/master/station_codes.csv) then you can do so easily with [`jq`](https://stedolan.github.io/jq/) (and `curl`) using an instance that has access to the staff API (and has been restarted recently). On Linux, you can install simply with your package manager, e.g. `sudo apt install jq` (on Ubuntu/Debian).


### PR DESCRIPTION
- Synced with latest upstream changes from master for ServiceID Guid.
- Removed the constraints on invalid serviceID (15 characters) 
- Make `ServiceIdUrlSafe` same as `serviceID` as it was breaking the recognisable ServiceID format.