### PR TITLE
Postcode api

### DIFF
--- a/Huxley2/Connected Services/NreOJPService/Reference.cs
+++ b/Huxley2/Connected Services/NreOJPService/Reference.cs
@@ -1317,15 +1317,7 @@ namespace NreOJPService
         [System.ServiceModel.OperationContractAttribute(Action="", ReplyAction="*")]
         System.Threading.Tasks.Task<NreOJPService.RealtimeJourneyPlanResponse1> RealtimeJourneyPlanAsync(NreOJPService.RealtimeJourneyPlanRequest1 request);
         
-        // CODEGEN: Generating message contract since the operation PostcodeJourneyPlan is neither RPC nor document wrapped.
-        [System.ServiceModel.OperationContractAttribute(Action="", ReplyAction="*")]
-        [System.ServiceModel.FaultContractAttribute(typeof(NreOJPService.PostcodeJourneyPlanFault), Action="", Name="PostcodeJourneyPlanFault", Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
-        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
-        [System.ServiceModel.ServiceKnownTypeAttribute(typeof(ReturnResponseType))]
-        NreOJPService.PostcodeJourneyPlanResponse1 PostcodeJourneyPlan(NreOJPService.PostcodeJourneyPlanRequest1 request);
-        
-        [System.ServiceModel.OperationContractAttribute(Action="", ReplyAction="*")]
-        System.Threading.Tasks.Task<NreOJPService.PostcodeJourneyPlanResponse1> PostcodeJourneyPlanAsync(NreOJPService.PostcodeJourneyPlanRequest1 request);
+
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -5035,32 +5027,7 @@ namespace NreOJPService
             return ((NreOJPService.jpservices)(this)).RealtimeJourneyPlanAsync(inValue);
         }
         
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
-        NreOJPService.PostcodeJourneyPlanResponse1 NreOJPService.jpservices.PostcodeJourneyPlan(NreOJPService.PostcodeJourneyPlanRequest1 request)
-        {
-            return base.Channel.PostcodeJourneyPlan(request);
-        }
-        
-        public NreOJPService.PostcodeJourneyPlanResponse PostcodeJourneyPlan(NreOJPService.PostcodeJourneyPlanRequest PostcodeJourneyPlanRequest)
-        {
-            NreOJPService.PostcodeJourneyPlanRequest1 inValue = new NreOJPService.PostcodeJourneyPlanRequest1();
-            inValue.PostcodeJourneyPlanRequest = PostcodeJourneyPlanRequest;
-            NreOJPService.PostcodeJourneyPlanResponse1 retVal = ((NreOJPService.jpservices)(this)).PostcodeJourneyPlan(inValue);
-            return retVal.PostcodeJourneyPlanResponse;
-        }
-        
-        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
-        System.Threading.Tasks.Task<NreOJPService.PostcodeJourneyPlanResponse1> NreOJPService.jpservices.PostcodeJourneyPlanAsync(NreOJPService.PostcodeJourneyPlanRequest1 request)
-        {
-            return base.Channel.PostcodeJourneyPlanAsync(request);
-        }
-        
-        public System.Threading.Tasks.Task<NreOJPService.PostcodeJourneyPlanResponse1> PostcodeJourneyPlanAsync(NreOJPService.PostcodeJourneyPlanRequest PostcodeJourneyPlanRequest)
-        {
-            NreOJPService.PostcodeJourneyPlanRequest1 inValue = new NreOJPService.PostcodeJourneyPlanRequest1();
-            inValue.PostcodeJourneyPlanRequest = PostcodeJourneyPlanRequest;
-            return ((NreOJPService.jpservices)(this)).PostcodeJourneyPlanAsync(inValue);
-        }
+
         
         public virtual System.Threading.Tasks.Task OpenAsync()
         {

--- a/Huxley2/Connected Services/NreOJPService/Reference.cs
+++ b/Huxley2/Connected Services/NreOJPService/Reference.cs
@@ -903,6 +903,385 @@ namespace NreOJPService
     {
     }
     
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeJourneyPlanFault : ReturnResponseType
+    {
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/common")]
+    public partial class PostcodeDetails
+    {
+        
+        private string postcodeField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
+        public string postcode
+        {
+            get
+            {
+                return this.postcodeField;
+            }
+            set
+            {
+                this.postcodeField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeJourneyPlanOrigin
+    {
+        
+        private PostcodeDetails postcodeDetailsField;
+        
+        private CrsCode stationField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Namespace="http://www.thalesgroup.com/ojp/common", Order=0)]
+        public PostcodeDetails postcodeDetails
+        {
+            get
+            {
+                return this.postcodeDetailsField;
+            }
+            set
+            {
+                this.postcodeDetailsField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Namespace="http://www.thalesgroup.com/ojp/common", Order=1)]
+        public CrsCode station
+        {
+            get
+            {
+                return this.stationField;
+            }
+            set
+            {
+                this.stationField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeJourneyPlanDestination
+    {
+        
+        private PostcodeDetails postcodeDetailsField;
+        
+        private CrsCode stationField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Namespace="http://www.thalesgroup.com/ojp/common", Order=0)]
+        public PostcodeDetails postcodeDetails
+        {
+            get
+            {
+                return this.postcodeDetailsField;
+            }
+            set
+            {
+                this.postcodeDetailsField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Namespace="http://www.thalesgroup.com/ojp/common", Order=1)]
+        public CrsCode station
+        {
+            get
+            {
+                return this.stationField;
+            }
+            set
+            {
+                this.stationField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeJourneyPlanRequestOutwardTime
+    {
+        
+        private System.DateTime itemField;
+        
+        private ItemChoiceType1 itemElementNameField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute("arriveBy", typeof(System.DateTime), Order=0)]
+        [System.Xml.Serialization.XmlElementAttribute("departBy", typeof(System.DateTime), Order=0)]
+        [System.Xml.Serialization.XmlChoiceIdentifierAttribute("ItemElementName")]
+        public System.DateTime Item
+        {
+            get
+            {
+                return this.itemField;
+            }
+            set
+            {
+                this.itemField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public ItemChoiceType1 ItemElementName
+        {
+            get
+            {
+                return this.itemElementNameField;
+            }
+            set
+            {
+                this.itemElementNameField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeJourneyPlanRequest
+    {
+        
+        private PostcodeJourneyPlanOrigin originField;
+        
+        private PostcodeJourneyPlanDestination destinationField;
+        
+        private RealtimeEnquiryType realtimeEnquiryField;
+        
+        private PostcodeJourneyPlanRequestOutwardTime outwardTimeField;
+        
+        private bool directTrainsField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
+        public PostcodeJourneyPlanOrigin origin
+        {
+            get
+            {
+                return this.originField;
+            }
+            set
+            {
+                this.originField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
+        public PostcodeJourneyPlanDestination destination
+        {
+            get
+            {
+                return this.destinationField;
+            }
+            set
+            {
+                this.destinationField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=2)]
+        public RealtimeEnquiryType realtimeEnquiry
+        {
+            get
+            {
+                return this.realtimeEnquiryField;
+            }
+            set
+            {
+                this.realtimeEnquiryField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=3)]
+        public PostcodeJourneyPlanRequestOutwardTime outwardTime
+        {
+            get
+            {
+                return this.outwardTimeField;
+            }
+            set
+            {
+                this.outwardTimeField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=4)]
+        public bool directTrains
+        {
+            get
+            {
+                return this.directTrainsField;
+            }
+            set
+            {
+                this.directTrainsField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeStation
+    {
+        
+        private string crsCodeField;
+        
+        private double distanceField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
+        public string crsCode
+        {
+            get
+            {
+                return this.crsCodeField;
+            }
+            set
+            {
+                this.crsCodeField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=1)]
+        public double distance
+        {
+            get
+            {
+                return this.distanceField;
+            }
+            set
+            {
+                this.distanceField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeResponseEntry
+    {
+        
+        private string selectedStationField;
+        
+        private Journey[] outwardJourneyField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
+        public string selectedStation
+        {
+            get
+            {
+                return this.selectedStationField;
+            }
+            set
+            {
+                this.selectedStationField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute("outwardJourney", Order=1)]
+        public Journey[] outwardJourney
+        {
+            get
+            {
+                return this.outwardJourneyField;
+            }
+            set
+            {
+                this.outwardJourneyField = value;
+            }
+        }
+    }
+    
+    /// <remarks/>
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.Xml.Serialization.XmlTypeAttribute(AnonymousType=true, Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+    public partial class PostcodeJourneyPlanResponse : ReturnResponseType
+    {
+        
+        private System.DateTime generatedTimeField;
+        
+        private PostcodeResponseEntry[] postcodeResponseField;
+        
+        private PostcodeStation[] postcodeStationsField;
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute(Order=0)]
+        public System.DateTime generatedTime
+        {
+            get
+            {
+                return this.generatedTimeField;
+            }
+            set
+            {
+                this.generatedTimeField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute("postcodeResponse", Order=1)]
+        public PostcodeResponseEntry[] postcodeResponse
+        {
+            get
+            {
+                return this.postcodeResponseField;
+            }
+            set
+            {
+                this.postcodeResponseField = value;
+            }
+        }
+        
+        /// <remarks/>
+        [System.Xml.Serialization.XmlElementAttribute("postcodeStations", Order=2)]
+        public PostcodeStation[] postcodeStations
+        {
+            get
+            {
+                return this.postcodeStationsField;
+            }
+            set
+            {
+                this.postcodeStationsField = value;
+            }
+        }
+    }
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
     [System.ServiceModel.ServiceContractAttribute(Namespace="https://ojp.nationalrail.co.uk", ConfigurationName="NreOJPService.jpservices")]
     public interface jpservices
@@ -937,6 +1316,16 @@ namespace NreOJPService
         
         [System.ServiceModel.OperationContractAttribute(Action="", ReplyAction="*")]
         System.Threading.Tasks.Task<NreOJPService.RealtimeJourneyPlanResponse1> RealtimeJourneyPlanAsync(NreOJPService.RealtimeJourneyPlanRequest1 request);
+        
+        // CODEGEN: Generating message contract since the operation PostcodeJourneyPlan is neither RPC nor document wrapped.
+        [System.ServiceModel.OperationContractAttribute(Action="", ReplyAction="*")]
+        [System.ServiceModel.FaultContractAttribute(typeof(NreOJPService.PostcodeJourneyPlanFault), Action="", Name="PostcodeJourneyPlanFault", Namespace="http://www.thalesgroup.com/ojp/jpdlr")]
+        [System.ServiceModel.XmlSerializerFormatAttribute(SupportFaults=true)]
+        [System.ServiceModel.ServiceKnownTypeAttribute(typeof(ReturnResponseType))]
+        NreOJPService.PostcodeJourneyPlanResponse1 PostcodeJourneyPlan(NreOJPService.PostcodeJourneyPlanRequest1 request);
+        
+        [System.ServiceModel.OperationContractAttribute(Action="", ReplyAction="*")]
+        System.Threading.Tasks.Task<NreOJPService.PostcodeJourneyPlanResponse1> PostcodeJourneyPlanAsync(NreOJPService.PostcodeJourneyPlanRequest1 request);
     }
     
     [System.Diagnostics.DebuggerStepThroughAttribute()]
@@ -4497,6 +4886,46 @@ namespace NreOJPService
         }
     }
     
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+    [System.ServiceModel.MessageContractAttribute(IsWrapped=false)]
+    public partial class PostcodeJourneyPlanRequest1
+    {
+        
+        [System.ServiceModel.MessageBodyMemberAttribute(Namespace="http://www.thalesgroup.com/ojp/jpdlr", Order=0)]
+        public NreOJPService.PostcodeJourneyPlanRequest PostcodeJourneyPlanRequest;
+        
+        public PostcodeJourneyPlanRequest1()
+        {
+        }
+        
+        public PostcodeJourneyPlanRequest1(NreOJPService.PostcodeJourneyPlanRequest PostcodeJourneyPlanRequest)
+        {
+            this.PostcodeJourneyPlanRequest = PostcodeJourneyPlanRequest;
+        }
+    }
+    
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
+    [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+    [System.ServiceModel.MessageContractAttribute(IsWrapped=false)]
+    public partial class PostcodeJourneyPlanResponse1
+    {
+        
+        [System.ServiceModel.MessageBodyMemberAttribute(Namespace="http://www.thalesgroup.com/ojp/jpdlr", Order=0)]
+        public NreOJPService.PostcodeJourneyPlanResponse PostcodeJourneyPlanResponse;
+        
+        public PostcodeJourneyPlanResponse1()
+        {
+        }
+        
+        public PostcodeJourneyPlanResponse1(NreOJPService.PostcodeJourneyPlanResponse PostcodeJourneyPlanResponse)
+        {
+            this.PostcodeJourneyPlanResponse = PostcodeJourneyPlanResponse;
+        }
+    }
+    
     [System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Tools.ServiceModel.Svcutil", "2.1.0")]
     public interface jpservicesChannel : NreOJPService.jpservices, System.ServiceModel.IClientChannel
     {
@@ -4604,6 +5033,33 @@ namespace NreOJPService
             NreOJPService.RealtimeJourneyPlanRequest1 inValue = new NreOJPService.RealtimeJourneyPlanRequest1();
             inValue.RealtimeJourneyPlanRequest = RealtimeJourneyPlanRequest;
             return ((NreOJPService.jpservices)(this)).RealtimeJourneyPlanAsync(inValue);
+        }
+        
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+        NreOJPService.PostcodeJourneyPlanResponse1 NreOJPService.jpservices.PostcodeJourneyPlan(NreOJPService.PostcodeJourneyPlanRequest1 request)
+        {
+            return base.Channel.PostcodeJourneyPlan(request);
+        }
+        
+        public NreOJPService.PostcodeJourneyPlanResponse PostcodeJourneyPlan(NreOJPService.PostcodeJourneyPlanRequest PostcodeJourneyPlanRequest)
+        {
+            NreOJPService.PostcodeJourneyPlanRequest1 inValue = new NreOJPService.PostcodeJourneyPlanRequest1();
+            inValue.PostcodeJourneyPlanRequest = PostcodeJourneyPlanRequest;
+            NreOJPService.PostcodeJourneyPlanResponse1 retVal = ((NreOJPService.jpservices)(this)).PostcodeJourneyPlan(inValue);
+            return retVal.PostcodeJourneyPlanResponse;
+        }
+        
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Advanced)]
+        System.Threading.Tasks.Task<NreOJPService.PostcodeJourneyPlanResponse1> NreOJPService.jpservices.PostcodeJourneyPlanAsync(NreOJPService.PostcodeJourneyPlanRequest1 request)
+        {
+            return base.Channel.PostcodeJourneyPlanAsync(request);
+        }
+        
+        public System.Threading.Tasks.Task<NreOJPService.PostcodeJourneyPlanResponse1> PostcodeJourneyPlanAsync(NreOJPService.PostcodeJourneyPlanRequest PostcodeJourneyPlanRequest)
+        {
+            NreOJPService.PostcodeJourneyPlanRequest1 inValue = new NreOJPService.PostcodeJourneyPlanRequest1();
+            inValue.PostcodeJourneyPlanRequest = PostcodeJourneyPlanRequest;
+            return ((NreOJPService.jpservices)(this)).PostcodeJourneyPlanAsync(inValue);
         }
         
         public virtual System.Threading.Tasks.Task OpenAsync()

--- a/Huxley2/Controllers/PostcodePlannerController.cs
+++ b/Huxley2/Controllers/PostcodePlannerController.cs
@@ -1,0 +1,211 @@
+using Huxley2.Interfaces;
+using Huxley2.Models;
+using Huxley2.Security;
+using Huxley2.Utils;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Diagnostics;
+using System.ServiceModel;
+using System.Threading.Tasks;
+
+namespace Huxley2.Controllers
+{
+    [Route("api/planner/postcode")]
+    [ApiController]
+    [RequireApiKey]
+    public class PostcodePlannerController : ControllerBase
+    {
+        private readonly ILogger<PostcodePlannerController> _logger;
+        private readonly IPostcodeJourneyPlannerService _postcodeService;
+
+        public PostcodePlannerController(
+            ILogger<PostcodePlannerController> logger,
+            IPostcodeJourneyPlannerService postcodeService)
+        {
+            _logger = logger;
+            _postcodeService = postcodeService;
+        }
+
+        // GET api/planner/postcode?origin=SW1A1AA&destination=PAD&plannedTime=2024-06-30T10:00:00
+        [HttpGet]
+        [ProducesResponseType(typeof(PostcodeJourneyPlanResponseModel), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiError), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ApiError), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ApiError), StatusCodes.Status502BadGateway)]
+        [ProducesResponseType(typeof(ApiError), StatusCodes.Status504GatewayTimeout)]
+        public async Task<ActionResult<PostcodeJourneyPlanResponseModel>> Get(
+            [FromQuery] PostcodeJourneyPlannerRequest request)
+        {
+            _logger.LogInformation(
+                "PostcodeJourneyPlan request. Origin={Origin} Destination={Destination} PlannedTime={PlannedTime}",
+                request.Origin, request.Destination, request.PlannedTime);
+
+            var clock = Stopwatch.StartNew();
+
+            try
+            {
+                // Classify origin and destination
+                var originUpper = request.Origin?.Trim().ToUpperInvariant() ?? string.Empty;
+                var destUpper = request.Destination?.Trim().ToUpperInvariant() ?? string.Empty;
+
+                var originIsCrs = CrsValidator.IsValidCrsCode(originUpper);
+                var destIsCrs = CrsValidator.IsValidCrsCode(destUpper);
+
+                // Neither is a postcode (both are CRS) → use standard planner
+                if (originIsCrs && destIsCrs)
+                {
+                    return BadRequest(new ApiError
+                    {
+                        Code = "USE_STANDARD_PLANNER",
+                        Message = "Both origin and destination are station codes. Use the standard journey planner instead.",
+                        TraceId = HttpContext.TraceIdentifier
+                    });
+                }
+
+                // Both are postcodes → not allowed
+                if (!originIsCrs && !destIsCrs)
+                {
+                    return BadRequest(new ApiError
+                    {
+                        Code = "POSTCODE_NOT_ALLOWED_FOR_BOTH",
+                        Message = "Postcodes cannot be used for both origin and destination. One must be a station code.",
+                        TraceId = HttpContext.TraceIdentifier
+                    });
+                }
+
+                // Determine which is the postcode and which is the CRS
+                bool originIsPostcode = !originIsCrs;
+                var rawPostcode = originIsPostcode ? originUpper : destUpper;
+                var stationCrs = originIsPostcode ? destUpper : originUpper;
+
+                // Validate postcode format
+                if (!PostcodeValidator.IsValidUkPostcode(rawPostcode))
+                {
+                    return BadRequest(new ApiError
+                    {
+                        Code = "INVALID_POSTCODE_FORMAT",
+                        Message = "The postcode provided is not a valid UK postcode format.",
+                        TraceId = HttpContext.TraceIdentifier
+                    });
+                }
+
+                var normalisedPostcode = PostcodeValidator.NormalisePostcode(rawPostcode);
+
+                var result = await _postcodeService.GetPostcodeJourneyPlanAsync(
+                    request, normalisedPostcode, stationCrs, originIsPostcode);
+
+                if (result == null)
+                {
+                    _logger.LogError("PostcodeJourneyPlan returned null response (unexpected).");
+                    return StatusCode(StatusCodes.Status502BadGateway, new ApiError
+                    {
+                        Code = "OJP_EMPTY_RESPONSE",
+                        Message = "Postcode journey planner returned an empty response. Please try again.",
+                        TraceId = HttpContext.TraceIdentifier
+                    });
+                }
+
+                _logger.LogInformation("PostcodeJourneyPlan success. GeneratedAt={GeneratedAt}", result.GeneratedAt);
+                return Ok(result);
+            }
+            catch (Huxley2.Exceptions.OjpFaultException ex)
+            {
+                var (status, message) = MapOjpFault(ex.FaultCode);
+
+                _logger.LogWarning(ex,
+                    "PostcodeJourneyPlan fault. Status={Status} Code={Code} Details={Details}",
+                    status, ex.FaultCode, ex.FaultDetails);
+
+                return StatusCode(status, new ApiError
+                {
+                    Code = ex.FaultCode ?? "OJP_FAULT",
+                    Message = message,
+                    Details = ex.FaultDetails,
+                    TraceId = HttpContext.TraceIdentifier
+                });
+            }
+            catch (TimeoutException ex)
+            {
+                _logger.LogWarning(ex, "PostcodeJourneyPlan timeout");
+                return StatusCode(StatusCodes.Status504GatewayTimeout, new ApiError
+                {
+                    Code = "OJP_TIMEOUT",
+                    Message = "Postcode journey planner is taking too long to respond. Please try again.",
+                    TraceId = HttpContext.TraceIdentifier
+                });
+            }
+            catch (CommunicationException ex)
+            {
+                _logger.LogError(ex, "PostcodeJourneyPlan upstream communication failure");
+                var innerMessage = ex.InnerException?.Message;
+                return StatusCode(StatusCodes.Status502BadGateway, new ApiError
+                {
+                    Code = "OJP_UPSTREAM_COMMUNICATION",
+                    Message = "Unable to connect to the journey planner service. This may be a temporary issue — please try again shortly.",
+                    Details = innerMessage,
+                    TraceId = HttpContext.TraceIdentifier
+                });
+            }
+            catch (Huxley2.Exceptions.OjpUpstreamException ex)
+            {
+                _logger.LogError(ex, "PostcodeJourneyPlan upstream failure");
+                return StatusCode(StatusCodes.Status502BadGateway, new ApiError
+                {
+                    Code = "OJP_UPSTREAM_ERROR",
+                    Message = "The journey planner service returned an unexpected response. Please try again.",
+                    Details = ex.Message,
+                    TraceId = HttpContext.TraceIdentifier
+                });
+            }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogWarning(ex, "PostcodeJourneyPlan request cancelled");
+                throw;
+            }
+            finally
+            {
+                clock.Stop();
+                _logger.LogInformation("PostcodeJourneyPlan elapsed {ElapsedMs}ms", clock.ElapsedMilliseconds);
+            }
+        }
+
+        private static (int StatusCode, string UserMessage) MapOjpFault(string? faultCode)
+        {
+            return faultCode switch
+            {
+                "OutwardDateTimeInThePast" => (
+                    StatusCodes.Status400BadRequest,
+                    "The time you selected is in the past. Please choose a future time and try again."),
+                "StationDoesNotExist" => (
+                    StatusCodes.Status400BadRequest,
+                    "The station code provided is not recognised. Please check and try again."),
+                "PostcodeMustBeProvided" => (
+                    StatusCodes.Status400BadRequest,
+                    "A postcode must be provided for either the origin or destination."),
+                "PostcodeDoesNotHaveAnyStations" => (
+                    StatusCodes.Status404NotFound,
+                    "No stations were found near the postcode provided."),
+                "PostcodeNotAllowedForFromAndTo" => (
+                    StatusCodes.Status400BadRequest,
+                    "Postcodes cannot be used for both origin and destination. One must be a station."),
+                "InvalidPostcode" => (
+                    StatusCodes.Status400BadRequest,
+                    "The postcode provided is not valid."),
+                "NoJourneysFound" => (
+                    StatusCodes.Status404NotFound,
+                    "No journeys were found for your request. Please check your dates, times, or route and try again."),
+                "JourneyPlanTimeout" or "DepartureBoardTimeout" => (
+                    StatusCodes.Status504GatewayTimeout,
+                    "The journey planner is taking too long to respond. Please try again."),
+                "JourneyPlanError" or "JourneyPlanNrsError" or "JourneyPlanNrsBadStatus" or "OJPOtherError" => (
+                    StatusCodes.Status502BadGateway,
+                    "The journey planner encountered an error. Please try again."),
+                _ => (
+                    StatusCodes.Status502BadGateway,
+                    "Postcode journey planner returned an error. Please try again.")
+            };
+        }
+    }
+}

--- a/Huxley2/Interfaces/IMapperService.cs
+++ b/Huxley2/Interfaces/IMapperService.cs
@@ -35,5 +35,7 @@ namespace Huxley2.Interfaces
         OpenLDBSVWS.GetNextDeparturesWithDetailsRequest MapGetNextDeparturesWithDetailsStaffRequest(StationBoardRequest request);
         OpenLDBSVWS.GetFastestDeparturesRequest MapGetFastestDeparturesStaffRequest(StationBoardRequest request);
         OpenLDBSVWS.GetFastestDeparturesWithDetailsRequest MapGetFastestDeparturesWithDetailsStaffRequest(StationBoardRequest request);
+
+        PostcodeJourneyPlanRequest1 MapPostcodeJourneyPlanRequest(PostcodeJourneyPlannerRequest request, string postcode, string stationCrs, bool originIsPostcode);
     }
 }

--- a/Huxley2/Interfaces/IMapperService.cs
+++ b/Huxley2/Interfaces/IMapperService.cs
@@ -35,7 +35,5 @@ namespace Huxley2.Interfaces
         OpenLDBSVWS.GetNextDeparturesWithDetailsRequest MapGetNextDeparturesWithDetailsStaffRequest(StationBoardRequest request);
         OpenLDBSVWS.GetFastestDeparturesRequest MapGetFastestDeparturesStaffRequest(StationBoardRequest request);
         OpenLDBSVWS.GetFastestDeparturesWithDetailsRequest MapGetFastestDeparturesWithDetailsStaffRequest(StationBoardRequest request);
-
-        PostcodeJourneyPlanRequest1 MapPostcodeJourneyPlanRequest(PostcodeJourneyPlannerRequest request, string postcode, string stationCrs, bool originIsPostcode);
     }
 }

--- a/Huxley2/Interfaces/IPostcodeJourneyPlannerService.cs
+++ b/Huxley2/Interfaces/IPostcodeJourneyPlannerService.cs
@@ -1,0 +1,14 @@
+using Huxley2.Models;
+using System.Threading.Tasks;
+
+namespace Huxley2.Interfaces
+{
+    public interface IPostcodeJourneyPlannerService
+    {
+        Task<PostcodeJourneyPlanResponseModel> GetPostcodeJourneyPlanAsync(
+            PostcodeJourneyPlannerRequest request,
+            string postcode,
+            string stationCrs,
+            bool originIsPostcode);
+    }
+}

--- a/Huxley2/Logging/SoapLoggingBehaviour.cs
+++ b/Huxley2/Logging/SoapLoggingBehaviour.cs
@@ -95,6 +95,14 @@ namespace Huxley2.Soap
                 ctx.Operation = "RealtimeCallingPoints";
                 ctx.FaultCode = ExtractFaultDetailValue(soap, "response");
                 ctx.FaultDetails = ExtractFaultDetailValue(soap, "responseDetails");
+                return;
+            }
+
+            if (soap.Contains("PostcodeJourneyPlanFault", StringComparison.Ordinal))
+            {
+                ctx.Operation = "PostcodeJourneyPlan";
+                ctx.FaultCode = ExtractFaultDetailValue(soap, "response");
+                ctx.FaultDetails = ExtractFaultDetailValue(soap, "responseDetails");
             }
         }
 

--- a/Huxley2/Models/PostcodeJourneyPlanResponseModel.cs
+++ b/Huxley2/Models/PostcodeJourneyPlanResponseModel.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Huxley2.Models
+{
+    public class PostcodeJourneyPlanResponseModel
+    {
+        public DateTime GeneratedAt { get; set; }
+
+        public DateTime PlannedTime { get; set; }
+
+        public string Postcode { get; set; } = string.Empty;
+
+        public string StationCrs { get; set; } = string.Empty;
+
+        public IEnumerable<PostcodeStationModel> PostcodeStations { get; set; } = new List<PostcodeStationModel>();
+
+        public IEnumerable<PostcodeJourneyGroup> OutwardJourneys { get; set; } = new List<PostcodeJourneyGroup>();
+    }
+
+    public class PostcodeStationModel
+    {
+        public string Crs { get; set; } = string.Empty;
+
+        public string StationName { get; set; } = string.Empty;
+
+        public double DistanceMiles { get; set; }
+    }
+
+    public class PostcodeJourneyGroup
+    {
+        public string SelectedStation { get; set; } = string.Empty;
+
+        public IEnumerable<OjpJourney> Journeys { get; set; } = new List<OjpJourney>();
+    }
+}

--- a/Huxley2/Models/PostcodeJourneyPlannerRequest.cs
+++ b/Huxley2/Models/PostcodeJourneyPlannerRequest.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Huxley2.Models
+{
+    public class PostcodeJourneyPlannerRequest
+    {
+        [Required]
+        [FromQuery]
+        public string Origin { get; set; } = string.Empty;
+
+        [Required]
+        [FromQuery]
+        public string Destination { get; set; } = string.Empty;
+
+        [Required]
+        [FromQuery]
+        public DateTime PlannedTime { get; set; }
+
+        [FromQuery]
+        public bool DirectTrains { get; set; } = false;
+
+        [FromQuery]
+        public int ItemChoiceType { get; set; } = 0;
+
+        [FromQuery]
+        public int EnquiryType { get; set; } = 0;
+    }
+}

--- a/Huxley2/Pages/Index.cshtml
+++ b/Huxley2/Pages/Index.cshtml
@@ -715,7 +715,7 @@
     <li><code>origin</code> (required) — A UK postcode or 3-letter CRS station code</li>
     <li><code>destination</code> (required) — A UK postcode or 3-letter CRS station code (exactly one must be a postcode)</li>
     <li><code>plannedTime</code> (required) — Journey date/time in ISO 8601 format (UK local time)</li>
-    <li><code>itemChoiceType</code> (optional, default 0) — 0 = Arrive By, 1 = Depart By, 2 = First Train, 3 = Last Train</li>
+    <li><code>itemChoiceType</code> (optional, default 0) — Supported values: 0 = Arrive By, 1 = Depart By</li>
     <li><code>enquiryType</code> (optional, default 0) — 0 = Standard, 1 = Check Alternatives</li>
     <li><code>directTrains</code> (optional, default false) — Restrict to direct services only</li>
 </ul>

--- a/Huxley2/Pages/Index.cshtml
+++ b/Huxley2/Pages/Index.cshtml
@@ -194,6 +194,11 @@
                                 </a>
                             </li>
                             <li>
+                                <a href="#postcode-planner">
+                                    Postcode Journey Planner
+                                </a>
+                            </li>
+                            <li>
                                 <a href="#auth">
                                     Authentication
                                 </a>
@@ -355,7 +360,7 @@
         <strong>Improved OJP error handling</strong> — comprehensive mapping of all OJP error codes to appropriate HTTP status codes with user-friendly messages.
     </li>
     <li>
-        <strong>OJP Postcode support confirmed</strong> — investigation confirmed the OJP API supports postcode-based journey planning (implementation planned for a future release).
+        <strong>Postcode Journey Planner</strong> — new <code>GET /api/planner/postcode</code> endpoint that plans journeys from/to a UK postcode, discovering nearby stations automatically via the NRE OJP API.
     </li>
     <li>
         Station responses now include latitude and longitude for map display.
@@ -694,6 +699,50 @@
     </code>
 </p>
 
+<h3 id="postcode-planner">Postcode Journey Planner</h3>
+<p>
+    Plan journeys from or to a UK postcode. The server auto-detects which parameter is a postcode
+    and which is a station CRS code. The OJP API discovers nearby stations and returns full journey
+    plans including multi-leg routes and Underground connections.
+</p>
+<p>
+    <code>
+        <a href="/api/planner/postcode?origin=SW1A1AA&amp;destination=EUS&amp;plannedTime=2026-06-01T10:00:00">/api/planner/postcode?origin={postcode|CRS}&amp;destination={CRS|postcode}&amp;plannedTime={DateTime}</a>
+    </code>
+</p>
+<h5>Parameters:</h5>
+<ul>
+    <li><code>origin</code> (required) — A UK postcode or 3-letter CRS station code</li>
+    <li><code>destination</code> (required) — A UK postcode or 3-letter CRS station code (exactly one must be a postcode)</li>
+    <li><code>plannedTime</code> (required) — Journey date/time in ISO 8601 format (UK local time)</li>
+    <li><code>itemChoiceType</code> (optional, default 0) — 0 = Arrive By, 1 = Depart By, 2 = First Train, 3 = Last Train</li>
+    <li><code>enquiryType</code> (optional, default 0) — 0 = Standard, 1 = Check Alternatives</li>
+    <li><code>directTrains</code> (optional, default false) — Restrict to direct services only</li>
+</ul>
+<h5>Examples:</h5>
+<ul>
+    <li>
+        Postcode as origin:
+        <code><a href="/api/planner/postcode?origin=SW1A1AA&amp;destination=EUS&amp;plannedTime=2026-06-01T10:00:00">/api/planner/postcode?origin=SW1A1AA&amp;destination=EUS&amp;plannedTime=2026-06-01T10:00:00</a></code>
+    </li>
+    <li>
+        Postcode as destination:
+        <code><a href="/api/planner/postcode?origin=WAT&amp;destination=TW32LN&amp;plannedTime=2026-06-01T10:00:00&amp;itemChoiceType=1">/api/planner/postcode?origin=WAT&amp;destination=TW32LN&amp;plannedTime=2026-06-01T10:00:00&amp;itemChoiceType=1</a></code>
+    </li>
+</ul>
+<h5>Response:</h5>
+<p>
+    Returns a JSON object with <code>postcodeStations</code> (nearby stations with CRS code, name, and distance in miles)
+    and <code>outwardJourneys</code> (journey plans grouped by selected station, each containing legs with departure/arrival
+    times, platforms, operators, fares, and service bulletins).
+</p>
+<h5>Constraints:</h5>
+<ul>
+    <li>Exactly one of origin/destination must be a UK postcode; the other must be a CRS code.</li>
+    <li>Postcodes are accepted with or without spaces, in any case (e.g. "SW1A 1AA", "sw1a1aa").</li>
+    <li>Some postcodes may return 404 if the OJP API has no station mappings for that area.</li>
+</ul>
+
 <h3 id="nearby">Nearby Services</h3>
 <p>
     Get real-time train services from stations near a GPS location in a single call.
@@ -761,8 +810,9 @@
         Pass as <code>accessToken</code> query parameter, or configure <code>DarwinAccessToken</code> in app settings.
     </li>
     <li>
-        <strong>Journey Planner</strong> — Requires a separate OJP username and password from NRE.
+        <strong>Journey Planner &amp; Postcode Planner</strong> — Requires a separate OJP username and password from NRE.
         Configure <code>ojpEndpoint</code>, <code>ojpUsername</code>, and <code>ojpPassword</code> in app settings.
+        Both the station-to-station planner and postcode planner use the same credentials.
     </li>
     <li>
         <strong>Nearby Services</strong> — Uses the server-configured <code>DarwinAccessToken</code> for upstream calls.

--- a/Huxley2/Services/MapperService.cs
+++ b/Huxley2/Services/MapperService.cs
@@ -106,24 +106,7 @@ namespace Huxley2.Services {
 
         private static ItemChoiceType1 GetItemChoiceType(JourneyPlannerRequest request)
         {
-            if (request.ItemChoiceType == 0)
-            {
-                return ItemChoiceType1.arriveBy;
-            }
-            else if (request.ItemChoiceType == 1)
-            {
-                return ItemChoiceType1.departBy;
-            }
-            else if (request.ItemChoiceType == 2)
-            {
-                return ItemChoiceType1.firstTrainOfDay;
-            }
-            else if (request.ItemChoiceType == 3)
-            {
-                return ItemChoiceType1.lastTrainOfDay;
-            }
-            return ItemChoiceType1.arriveBy;
-
+            return GetItemChoiceType(request.ItemChoiceType);
         }
 
         private static RealtimeEnquiryType GetRealtimeEnquiryType(JourneyPlannerRequest request)
@@ -394,6 +377,49 @@ namespace Huxley2.Services {
                 time = _dateTimeService.LocalNow.AddMinutes(request.TimeOffset), // local - not UTC
                 timeWindow = (ushort)request.TimeWindow, // max 1440mins (24hrs)
                 services = STAFF_SERVICES_CODES,
+            };
+        }
+
+        public PostcodeJourneyPlanRequest1 MapPostcodeJourneyPlanRequest(
+            PostcodeJourneyPlannerRequest request, string postcode, string stationCrs, bool originIsPostcode) {
+
+            var origin = new PostcodeJourneyPlanOrigin();
+            var destination = new PostcodeJourneyPlanDestination();
+
+            if (originIsPostcode) {
+                origin.postcodeDetails = new PostcodeDetails { postcode = postcode };
+                destination.station = makeJPCrsCode(stationCrs);
+            } else {
+                origin.station = makeJPCrsCode(stationCrs);
+                destination.postcodeDetails = new PostcodeDetails { postcode = postcode };
+            }
+
+            var itemChoiceType = GetItemChoiceType(request.ItemChoiceType);
+
+            var soapRequest = new NreOJPService.PostcodeJourneyPlanRequest {
+                origin = origin,
+                destination = destination,
+                realtimeEnquiry = request.EnquiryType == 0
+                    ? RealtimeEnquiryType.STANDARD
+                    : RealtimeEnquiryType.CHECK_ALTERNATIVES,
+                outwardTime = new PostcodeJourneyPlanRequestOutwardTime {
+                    Item = request.PlannedTime,
+                    ItemElementName = itemChoiceType
+                },
+                directTrains = request.DirectTrains
+            };
+
+            return new PostcodeJourneyPlanRequest1 {
+                PostcodeJourneyPlanRequest = soapRequest
+            };
+        }
+
+        private static ItemChoiceType1 GetItemChoiceType(int itemChoiceType) {
+            return itemChoiceType switch {
+                1 => ItemChoiceType1.departBy,
+                2 => ItemChoiceType1.firstTrainOfDay,
+                3 => ItemChoiceType1.lastTrainOfDay,
+                _ => ItemChoiceType1.arriveBy
             };
         }
 

--- a/Huxley2/Services/MapperService.cs
+++ b/Huxley2/Services/MapperService.cs
@@ -106,7 +106,12 @@ namespace Huxley2.Services {
 
         private static ItemChoiceType1 GetItemChoiceType(JourneyPlannerRequest request)
         {
-            return GetItemChoiceType(request.ItemChoiceType);
+            return request.ItemChoiceType switch {
+                1 => ItemChoiceType1.departBy,
+                2 => ItemChoiceType1.firstTrainOfDay,
+                3 => ItemChoiceType1.lastTrainOfDay,
+                _ => ItemChoiceType1.arriveBy
+            };
         }
 
         private static RealtimeEnquiryType GetRealtimeEnquiryType(JourneyPlannerRequest request)
@@ -377,49 +382,6 @@ namespace Huxley2.Services {
                 time = _dateTimeService.LocalNow.AddMinutes(request.TimeOffset), // local - not UTC
                 timeWindow = (ushort)request.TimeWindow, // max 1440mins (24hrs)
                 services = STAFF_SERVICES_CODES,
-            };
-        }
-
-        public PostcodeJourneyPlanRequest1 MapPostcodeJourneyPlanRequest(
-            PostcodeJourneyPlannerRequest request, string postcode, string stationCrs, bool originIsPostcode) {
-
-            var origin = new PostcodeJourneyPlanOrigin();
-            var destination = new PostcodeJourneyPlanDestination();
-
-            if (originIsPostcode) {
-                origin.postcodeDetails = new PostcodeDetails { postcode = postcode };
-                destination.station = makeJPCrsCode(stationCrs);
-            } else {
-                origin.station = makeJPCrsCode(stationCrs);
-                destination.postcodeDetails = new PostcodeDetails { postcode = postcode };
-            }
-
-            var itemChoiceType = GetItemChoiceType(request.ItemChoiceType);
-
-            var soapRequest = new NreOJPService.PostcodeJourneyPlanRequest {
-                origin = origin,
-                destination = destination,
-                realtimeEnquiry = request.EnquiryType == 0
-                    ? RealtimeEnquiryType.STANDARD
-                    : RealtimeEnquiryType.CHECK_ALTERNATIVES,
-                outwardTime = new PostcodeJourneyPlanRequestOutwardTime {
-                    Item = request.PlannedTime,
-                    ItemElementName = itemChoiceType
-                },
-                directTrains = request.DirectTrains
-            };
-
-            return new PostcodeJourneyPlanRequest1 {
-                PostcodeJourneyPlanRequest = soapRequest
-            };
-        }
-
-        private static ItemChoiceType1 GetItemChoiceType(int itemChoiceType) {
-            return itemChoiceType switch {
-                1 => ItemChoiceType1.departBy,
-                2 => ItemChoiceType1.firstTrainOfDay,
-                3 => ItemChoiceType1.lastTrainOfDay,
-                _ => ItemChoiceType1.arriveBy
             };
         }
 

--- a/Huxley2/Services/PostcodeJourneyPlannerService.cs
+++ b/Huxley2/Services/PostcodeJourneyPlannerService.cs
@@ -1,0 +1,539 @@
+using Huxley2.Exceptions;
+using Huxley2.Interfaces;
+using Huxley2.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NreOJPService;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Huxley2.Services
+{
+    public class PostcodeJourneyPlannerService : IPostcodeJourneyPlannerService
+    {
+        private readonly ILogger<PostcodeJourneyPlannerService> _logger;
+        private readonly IStationService _stationService;
+        private readonly HttpClient _httpClient;
+        private readonly string _endpoint;
+        private readonly string _username;
+        private readonly string _password;
+
+        public PostcodeJourneyPlannerService(
+            ILogger<PostcodeJourneyPlannerService> logger,
+            IStationService stationService,
+            HttpClient httpClient,
+            IConfiguration config)
+        {
+            _logger = logger;
+            _stationService = stationService;
+            _httpClient = httpClient;
+
+            _endpoint = config["ojpEndpoint"]
+                ?? config.GetConnectionString("ojpEndpoint")
+                ?? throw new InvalidOperationException("Missing ojpEndpoint");
+            _username = config["ojpUsername"]
+                ?? config.GetConnectionString("ojpUsername")
+                ?? throw new InvalidOperationException("Missing ojpUsername");
+            _password = config["ojpPassword"]
+                ?? config.GetConnectionString("ojpPassword")
+                ?? throw new InvalidOperationException("Missing ojpPassword");
+        }
+
+        public async Task<PostcodeJourneyPlanResponseModel> GetPostcodeJourneyPlanAsync(
+            PostcodeJourneyPlannerRequest request,
+            string postcode,
+            string stationCrs,
+            bool originIsPostcode)
+        {
+            var sw = Stopwatch.StartNew();
+            _logger.LogInformation("Calling OJP raw SOAP PostcodeJourneyPlan");
+
+            try
+            {
+                var soapXml = BuildSoapRequest(postcode, stationCrs, originIsPostcode, request);
+                _logger.LogInformation("OJP SOAP REQUEST (postcode):\n{Soap}", soapXml);
+
+                var httpRequest = new HttpRequestMessage(HttpMethod.Post, _endpoint);
+                httpRequest.Content = new StringContent(soapXml, Encoding.UTF8, "text/xml");
+                httpRequest.Headers.Add("SOAPAction", "\"\"");
+
+                var authBytes = Encoding.ASCII.GetBytes($"{_username}:{_password}");
+                httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+
+                HttpResponseMessage httpResponse;
+                try
+                {
+                    httpResponse = await _httpClient.SendAsync(httpRequest);
+                }
+                catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
+                {
+                    sw.Stop();
+                    _logger.LogError(ex, "OJP SOAP timeout (postcode) ElapsedMs={ElapsedMs}", sw.ElapsedMilliseconds);
+                    throw new TimeoutException("OJP PostcodeJourneyPlan request timed out", ex);
+                }
+                catch (HttpRequestException ex)
+                {
+                    sw.Stop();
+                    _logger.LogError(ex, "OJP SOAP communication error (postcode) ElapsedMs={ElapsedMs}", sw.ElapsedMilliseconds);
+                    throw new System.ServiceModel.CommunicationException("OJP PostcodeJourneyPlan communication failure", ex);
+                }
+
+                var responseXml = await httpResponse.Content.ReadAsStringAsync();
+                _logger.LogInformation("OJP SOAP RESPONSE (postcode):\n{Soap}", responseXml);
+
+                XDocument doc;
+                try
+                {
+                    doc = XDocument.Parse(responseXml);
+                }
+                catch (System.Xml.XmlException ex)
+                {
+                    _logger.LogError(ex, "Failed to parse OJP SOAP response XML (postcode)");
+                    throw new OjpUpstreamException("PostcodeJourneyPlan returned invalid XML", ex);
+                }
+
+                // Check for SOAP Fault (HTTP 500 from OJP for schema validation errors)
+                var faultEl = doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "Fault");
+                if (faultEl != null)
+                {
+                    var faultString = faultEl.Descendants().FirstOrDefault(e => e.Name.LocalName == "faultstring")?.Value;
+                    _logger.LogWarning("OJP SOAP Fault (postcode): {FaultString}", faultString);
+                    throw new OjpUpstreamException($"PostcodeJourneyPlan SOAP Fault: {faultString}");
+                }
+
+                // Check for PostcodeJourneyPlanFault element (OJP-level fault in body)
+                var pcFault = doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "PostcodeJourneyPlanFault");
+                if (pcFault != null)
+                {
+                    var faultResponse = pcFault.Descendants().FirstOrDefault(e => e.Name.LocalName == "response")?.Value;
+                    var faultDetails = pcFault.Descendants().FirstOrDefault(e => e.Name.LocalName == "responseDetails")?.Value;
+
+                    _logger.LogWarning(
+                        "OJP PostcodeJourneyPlanFault. Response={Response}, Details={Details}",
+                        faultResponse, faultDetails);
+
+                    throw new OjpFaultException(
+                        operation: "PostcodeJourneyPlan",
+                        response: faultResponse,
+                        responseDetails: faultDetails);
+                }
+
+                // Find the PostcodeJourneyPlanResponse element
+                var pcResponseEl = doc.Descendants().FirstOrDefault(e => e.Name.LocalName == "PostcodeJourneyPlanResponse");
+                if (pcResponseEl == null)
+                {
+                    _logger.LogError("OJP SOAP returned no PostcodeJourneyPlanResponse element");
+                    throw new OjpUpstreamException("PostcodeJourneyPlan SOAP response missing PostcodeJourneyPlanResponse element");
+                }
+
+                // Check response status
+                var responseStatus = pcResponseEl.Elements().FirstOrDefault(e => e.Name.LocalName == "response")?.Value;
+                var responseDetails = pcResponseEl.Elements().FirstOrDefault(e => e.Name.LocalName == "responseDetails")?.Value;
+
+                if (responseStatus != null && responseStatus != "Ok")
+                {
+                    _logger.LogWarning(
+                        "OJP SOAP non-Ok response (postcode). Response={Response}, Details={Details}",
+                        responseStatus, responseDetails);
+
+                    throw new OjpFaultException(
+                        operation: "PostcodeJourneyPlan",
+                        response: responseStatus,
+                        responseDetails: responseDetails);
+                }
+
+                // Parse generatedTime
+                var generatedTimeStr = pcResponseEl.Elements().FirstOrDefault(e => e.Name.LocalName == "generatedTime")?.Value;
+                var generatedTime = DateTime.TryParse(generatedTimeStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var gt)
+                    ? gt : DateTime.UtcNow;
+
+                // Parse postcodeStations
+                var postcodeStations = ParsePostcodeStations(pcResponseEl);
+
+                // Parse postcodeResponse entries → journey groups
+                var outwardJourneys = ParsePostcodeResponses(pcResponseEl);
+
+                sw.Stop();
+                _logger.LogInformation(
+                    "OJP SOAP postcode success GeneratedTime={GeneratedTime:o} ElapsedMs={ElapsedMs}",
+                    generatedTime, sw.ElapsedMilliseconds);
+
+                return new PostcodeJourneyPlanResponseModel
+                {
+                    GeneratedAt = generatedTime,
+                    PlannedTime = request.PlannedTime,
+                    Postcode = postcode,
+                    StationCrs = stationCrs,
+                    PostcodeStations = postcodeStations,
+                    OutwardJourneys = outwardJourneys
+                };
+            }
+            catch (OjpFaultException) { throw; }
+            catch (OjpUpstreamException) { throw; }
+            catch (TimeoutException) { throw; }
+            catch (System.ServiceModel.CommunicationException) { throw; }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _logger.LogError(ex, "OJP SOAP unexpected error (postcode) ElapsedMs={ElapsedMs}", sw.ElapsedMilliseconds);
+                throw;
+            }
+        }
+
+        private string BuildSoapRequest(string postcode, string stationCrs, bool originIsPostcode, PostcodeJourneyPlannerRequest request)
+        {
+            string originXml;
+            string destinationXml;
+
+            if (originIsPostcode)
+            {
+                originXml = $@"<jpd:origin>
+        <com:postcodeDetails>
+          <com:postcode>{EscapeXml(postcode)}</com:postcode>
+        </com:postcodeDetails>
+      </jpd:origin>";
+                destinationXml = $@"<jpd:destination>
+        <com:station>
+          <com:stationCRS>{EscapeXml(stationCrs)}</com:stationCRS>
+        </com:station>
+      </jpd:destination>";
+            }
+            else
+            {
+                originXml = $@"<jpd:origin>
+        <com:station>
+          <com:stationCRS>{EscapeXml(stationCrs)}</com:stationCRS>
+        </com:station>
+      </jpd:origin>";
+                destinationXml = $@"<jpd:destination>
+        <com:postcodeDetails>
+          <com:postcode>{EscapeXml(postcode)}</com:postcode>
+        </com:postcodeDetails>
+      </jpd:destination>";
+            }
+
+            var timeElementName = GetTimeElementName(request.ItemChoiceType);
+            var dateTimeStr = request.PlannedTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
+            var enquiryType = request.EnquiryType == 0 ? "STANDARD" : "CHECK_ALTERNATIVES";
+            var directTrains = request.DirectTrains ? "true" : "false";
+
+            return $@"<soapenv:Envelope xmlns:soapenv=""http://schemas.xmlsoap.org/soap/envelope/"" xmlns:jpd=""http://www.thalesgroup.com/ojp/jpdlr"" xmlns:com=""http://www.thalesgroup.com/ojp/common"">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <jpd:PostcodeJourneyPlanRequest>
+      {originXml}
+      {destinationXml}
+      <jpd:realtimeEnquiry>{enquiryType}</jpd:realtimeEnquiry>
+      <jpd:outwardTime>
+        <jpd:{timeElementName}>{dateTimeStr}</jpd:{timeElementName}>
+      </jpd:outwardTime>
+      <jpd:directTrains>{directTrains}</jpd:directTrains>
+    </jpd:PostcodeJourneyPlanRequest>
+  </soapenv:Body>
+</soapenv:Envelope>";
+        }
+
+        private static string GetTimeElementName(int itemChoiceType)
+        {
+            return itemChoiceType switch
+            {
+                0 => "arriveBy",
+                1 => "departBy",
+                2 => "firstTrainOfDay",
+                3 => "lastTrainOfDay",
+                _ => "departBy"
+            };
+        }
+
+        private static string EscapeXml(string value)
+        {
+            return value
+                .Replace("&", "&amp;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("\"", "&quot;")
+                .Replace("'", "&apos;");
+        }
+
+        private List<PostcodeStationModel> ParsePostcodeStations(XElement pcResponseEl)
+        {
+            var stations = new List<PostcodeStationModel>();
+            var stationElements = pcResponseEl.Elements().Where(e => e.Name.LocalName == "postcodeStations");
+
+            foreach (var stEl in stationElements)
+            {
+                var crs = stEl.Elements().FirstOrDefault(e => e.Name.LocalName == "crsCode")?.Value ?? string.Empty;
+                var distStr = stEl.Elements().FirstOrDefault(e => e.Name.LocalName == "distance")?.Value;
+                double.TryParse(distStr, NumberStyles.Float, CultureInfo.InvariantCulture, out var distance);
+
+                var station = _stationService.GetStationByCrsCode(crs);
+                stations.Add(new PostcodeStationModel
+                {
+                    Crs = crs,
+                    StationName = station?.StationName ?? crs,
+                    DistanceMiles = distance
+                });
+            }
+
+            return stations;
+        }
+
+        private List<PostcodeJourneyGroup> ParsePostcodeResponses(XElement pcResponseEl)
+        {
+            var groups = new List<PostcodeJourneyGroup>();
+            var responseElements = pcResponseEl.Elements().Where(e => e.Name.LocalName == "postcodeResponse");
+
+            foreach (var respEl in responseElements)
+            {
+                var selectedStation = respEl.Elements().FirstOrDefault(e => e.Name.LocalName == "selectedStation")?.Value ?? string.Empty;
+                var journeys = new List<OjpJourney>();
+
+                var journeyElements = respEl.Elements().Where(e => e.Name.LocalName == "outwardJourney");
+                foreach (var jEl in journeyElements)
+                {
+                    journeys.Add(ParseJourney(jEl));
+                }
+
+                groups.Add(new PostcodeJourneyGroup
+                {
+                    SelectedStation = selectedStation,
+                    Journeys = journeys
+                });
+            }
+
+            return groups;
+        }
+
+        private OjpJourney ParseJourney(XElement journeyEl)
+        {
+            var idStr = journeyEl.Elements().FirstOrDefault(e => e.Name.LocalName == "id")?.Value;
+            int.TryParse(idStr, out var id);
+
+            var origin = journeyEl.Elements().FirstOrDefault(e => e.Name.LocalName == "origin")?.Value ?? string.Empty;
+            var destination = journeyEl.Elements().FirstOrDefault(e => e.Name.LocalName == "destination")?.Value ?? string.Empty;
+            var rtClassification = journeyEl.Elements().FirstOrDefault(e => e.Name.LocalName == "realtimeClassification")?.Value;
+
+            var timetableEl = journeyEl.Elements().FirstOrDefault(e => e.Name.LocalName == "timetable");
+            var journeyTimetable = timetableEl != null ? ParseJourneyTimetable(timetableEl) : null;
+
+            var legs = new List<OjpLeg>();
+            var legElements = journeyEl.Elements().Where(e => e.Name.LocalName == "leg");
+            foreach (var legEl in legElements)
+            {
+                legs.Add(ParseLeg(legEl));
+            }
+
+            var fares = new List<Fare>();
+            var fareElements = journeyEl.Elements().Where(e => e.Name.LocalName == "fare");
+            foreach (var fareEl in fareElements)
+            {
+                fares.Add(ParseFare(fareEl));
+            }
+
+            var bulletins = new List<ServiceBulletin>();
+            var bulletinElements = journeyEl.Elements().Where(e => e.Name.LocalName == "serviceBulletins");
+            foreach (var bEl in bulletinElements)
+            {
+                bulletins.Add(ParseServiceBulletin(bEl));
+            }
+
+            return new OjpJourney
+            {
+                Id = id,
+                OriginStation = _stationService.GetStationByCrsCode(origin),
+                DestinationStation = _stationService.GetStationByCrsCode(destination),
+                RealTimeClassification = rtClassification,
+                JourneyTimetable = journeyTimetable,
+                OjpLegs = legs,
+                Fare = fares,
+                ServiceBulletins = bulletins
+            };
+        }
+
+        private OjpLeg ParseLeg(XElement legEl)
+        {
+            var idStr = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "id")?.Value;
+            int.TryParse(idStr, out var id);
+
+            var board = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "board")?.Value ?? string.Empty;
+            var alight = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "alight")?.Value ?? string.Empty;
+
+            var origins = legEl.Elements().Where(e => e.Name.LocalName == "origins").Select(e => e.Value).ToArray();
+            var destinations = legEl.Elements().Where(e => e.Name.LocalName == "destinations").Select(e => e.Value).ToArray();
+
+            var originPlatform = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "originPlatform")?.Value;
+            var destPlatform = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "destinationPlatform")?.Value;
+            var rtClassification = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "realtimeClassification")?.Value;
+            var mode = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "mode")?.Value;
+
+            var operatorEl = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "operator");
+            OperatorDetails? operatorDetails = null;
+            if (operatorEl != null)
+            {
+                operatorDetails = ParseOperatorDetails(operatorEl);
+            }
+
+            var timetableEl = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "timetable");
+            JourneyLegTimetable? legTimetable = null;
+            if (timetableEl != null)
+            {
+                legTimetable = ParseLegTimetable(timetableEl);
+            }
+
+            var undergroundInfo = legEl.Elements()
+                .Where(e => e.Name.LocalName == "undergroundTravelInformation")
+                .Select(e => e.Value).ToArray();
+
+            return new OjpLeg
+            {
+                Id = id,
+                BoardStation = _stationService.GetStationByCrsCode(board),
+                AlightStation = _stationService.GetStationByCrsCode(alight),
+                Origins = origins.Length > 0 ? origins : Array.Empty<string>(),
+                Destinations = destinations.Length > 0 ? destinations : Array.Empty<string>(),
+                OriginPlatform = originPlatform,
+                DestinationPlatform = destPlatform,
+                RealTimeClassification = rtClassification,
+                TravelMode = mode,
+                OperatorDetails = operatorDetails,
+                JourneyTimetable = legTimetable,
+                UndergroundTravelInformation = undergroundInfo.Length > 0 ? undergroundInfo : Array.Empty<string>()
+            };
+        }
+
+        private static JourneyTimetable ParseJourneyTimetable(XElement timetableEl)
+        {
+            var tt = new JourneyTimetable();
+
+            var scheduledEl = timetableEl.Elements().FirstOrDefault(e => e.Name.LocalName == "scheduled");
+            if (scheduledEl != null)
+            {
+                tt.scheduled = new JourneyTimetableScheduled();
+                var depStr = scheduledEl.Elements().FirstOrDefault(e => e.Name.LocalName == "departure")?.Value;
+                var arrStr = scheduledEl.Elements().FirstOrDefault(e => e.Name.LocalName == "arrival")?.Value;
+                if (DateTime.TryParse(depStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dep))
+                    tt.scheduled.departure = dep;
+                if (DateTime.TryParse(arrStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var arr))
+                    tt.scheduled.arrival = arr;
+            }
+
+            var realtimeEl = timetableEl.Elements().FirstOrDefault(e => e.Name.LocalName == "realtime");
+            if (realtimeEl != null)
+            {
+                tt.realtime = new JourneyTimetableRealtime();
+                var depStr = realtimeEl.Elements().FirstOrDefault(e => e.Name.LocalName == "departure")?.Value;
+                var arrStr = realtimeEl.Elements().FirstOrDefault(e => e.Name.LocalName == "arrival")?.Value;
+                if (DateTime.TryParse(depStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dep))
+                {
+                    tt.realtime.departure = dep;
+                    tt.realtime.departureSpecified = true;
+                }
+                if (DateTime.TryParse(arrStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var arr))
+                {
+                    tt.realtime.arrival = arr;
+                    tt.realtime.arrivalSpecified = true;
+                }
+            }
+
+            return tt;
+        }
+
+        private static JourneyLegTimetable ParseLegTimetable(XElement timetableEl)
+        {
+            var tt = new JourneyLegTimetable();
+
+            var scheduledEl = timetableEl.Elements().FirstOrDefault(e => e.Name.LocalName == "scheduled");
+            if (scheduledEl != null)
+            {
+                tt.scheduled = new JourneyLegTimetableScheduled();
+                var depStr = scheduledEl.Elements().FirstOrDefault(e => e.Name.LocalName == "departure")?.Value;
+                var arrStr = scheduledEl.Elements().FirstOrDefault(e => e.Name.LocalName == "arrival")?.Value;
+                if (DateTime.TryParse(depStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dep))
+                    tt.scheduled.departure = dep;
+                if (DateTime.TryParse(arrStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var arr))
+                    tt.scheduled.arrival = arr;
+            }
+
+            var realtimeEl = timetableEl.Elements().FirstOrDefault(e => e.Name.LocalName == "realtime");
+            if (realtimeEl != null)
+            {
+                tt.realtime = new JourneyLegTimetableRealtime();
+                var depStr = realtimeEl.Elements().FirstOrDefault(e => e.Name.LocalName == "departure")?.Value;
+                var arrStr = realtimeEl.Elements().FirstOrDefault(e => e.Name.LocalName == "arrival")?.Value;
+                if (DateTime.TryParse(depStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dep))
+                {
+                    tt.realtime.departure = dep;
+                    tt.realtime.departureSpecified = true;
+                }
+                if (DateTime.TryParse(arrStr, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var arr))
+                {
+                    tt.realtime.arrival = arr;
+                    tt.realtime.arrivalSpecified = true;
+                }
+            }
+
+            return tt;
+        }
+
+        private static OperatorDetails ParseOperatorDetails(XElement opEl)
+        {
+            return new OperatorDetails
+            {
+                code = opEl.Elements().FirstOrDefault(e => e.Name.LocalName == "code")?.Value,
+                name = opEl.Elements().FirstOrDefault(e => e.Name.LocalName == "name")?.Value
+            };
+        }
+
+        private static Fare ParseFare(XElement fareEl)
+        {
+            var fare = new Fare();
+
+            var idStr = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "id")?.Value;
+            if (int.TryParse(idStr, out var id)) fare.id = id;
+
+            fare.description = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "description")?.Value;
+
+            var totalPriceStr = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "totalPrice")?.Value;
+            if (int.TryParse(totalPriceStr, out var totalPrice)) fare.totalPrice = totalPrice;
+
+            fare.typeCode = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "typeCode")?.Value;
+            fare.routeCode = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "routeCode")?.Value;
+            fare.fareSetter = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "fareSetter")?.Value;
+
+            var startLegStr = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "startLegId")?.Value;
+            if (int.TryParse(startLegStr, out var startLeg)) fare.startLegId = startLeg;
+
+            var endLegStr = fareEl.Elements().FirstOrDefault(e => e.Name.LocalName == "endLegId")?.Value;
+            if (int.TryParse(endLegStr, out var endLeg)) fare.endLegId = endLeg;
+
+            return fare;
+        }
+
+        private static ServiceBulletin ParseServiceBulletin(XElement bEl)
+        {
+            var bulletin = new ServiceBulletin();
+            bulletin.title = bEl.Elements().FirstOrDefault(e => e.Name.LocalName == "title")?.Value;
+            bulletin.description = bEl.Elements().FirstOrDefault(e => e.Name.LocalName == "description")?.Value;
+            bulletin.url = bEl.Elements().FirstOrDefault(e => e.Name.LocalName == "url")?.Value;
+
+            var disruptionStr = bEl.Elements().FirstOrDefault(e => e.Name.LocalName == "disruption")?.Value;
+            if (bool.TryParse(disruptionStr, out var disruption)) bulletin.disruption = disruption;
+
+            var alertStr = bEl.Elements().FirstOrDefault(e => e.Name.LocalName == "alert")?.Value;
+            if (bool.TryParse(alertStr, out var alert)) bulletin.alert = alert;
+
+            var clearedStr = bEl.Elements().FirstOrDefault(e => e.Name.LocalName == "cleared")?.Value;
+            if (bool.TryParse(clearedStr, out var cleared)) bulletin.cleared = cleared;
+
+            return bulletin;
+        }
+    }
+}

--- a/Huxley2/Services/PostcodeJourneyPlannerService.cs
+++ b/Huxley2/Services/PostcodeJourneyPlannerService.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
@@ -61,30 +62,15 @@ namespace Huxley2.Services
                 var soapXml = BuildSoapRequest(postcode, stationCrs, originIsPostcode, request);
                 _logger.LogDebug("OJP SOAP REQUEST (postcode):\n{Soap}", soapXml);
 
-                var httpRequest = new HttpRequestMessage(HttpMethod.Post, _endpoint);
+                using var httpRequest = new HttpRequestMessage(HttpMethod.Post, _endpoint);
                 httpRequest.Content = new StringContent(soapXml, Encoding.UTF8, "text/xml");
                 httpRequest.Headers.Add("SOAPAction", "\"\"");
 
                 var authBytes = Encoding.ASCII.GetBytes($"{_username}:{_password}");
                 httpRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
 
-                HttpResponseMessage httpResponse;
-                try
-                {
-                    httpResponse = await _httpClient.SendAsync(httpRequest);
-                }
-                catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
-                {
-                    sw.Stop();
-                    _logger.LogError(ex, "OJP SOAP timeout (postcode) ElapsedMs={ElapsedMs}", sw.ElapsedMilliseconds);
-                    throw new TimeoutException("OJP PostcodeJourneyPlan request timed out", ex);
-                }
-                catch (HttpRequestException ex)
-                {
-                    sw.Stop();
-                    _logger.LogError(ex, "OJP SOAP communication error (postcode) ElapsedMs={ElapsedMs}", sw.ElapsedMilliseconds);
-                    throw new System.ServiceModel.CommunicationException("OJP PostcodeJourneyPlan communication failure", ex);
-                }
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                using var httpResponse = await _httpClient.SendAsync(httpRequest, cts.Token);
 
                 var responseXml = await httpResponse.Content.ReadAsStringAsync();
                 _logger.LogDebug("OJP SOAP RESPONSE (postcode):\n{Soap}", responseXml);
@@ -180,6 +166,18 @@ namespace Huxley2.Services
             catch (OjpUpstreamException) { throw; }
             catch (TimeoutException) { throw; }
             catch (System.ServiceModel.CommunicationException) { throw; }
+            catch (TaskCanceledException ex) when (!ex.CancellationToken.IsCancellationRequested)
+            {
+                sw.Stop();
+                _logger.LogError(ex, "OJP SOAP timeout (postcode) ElapsedMs={ElapsedMs}", sw.ElapsedMilliseconds);
+                throw new TimeoutException("OJP PostcodeJourneyPlan request timed out", ex);
+            }
+            catch (HttpRequestException ex)
+            {
+                sw.Stop();
+                _logger.LogError(ex, "OJP SOAP communication error (postcode) ElapsedMs={ElapsedMs}", sw.ElapsedMilliseconds);
+                throw new System.ServiceModel.CommunicationException("OJP PostcodeJourneyPlan communication failure", ex);
+            }
             catch (Exception ex)
             {
                 sw.Stop();
@@ -247,12 +245,12 @@ namespace Huxley2.Services
 
         private static string GetTimeElementName(int itemChoiceType)
         {
+            // PostcodeJourneyPlanRequest only supports arriveBy and departBy.
+            // Map firstTrainOfDay/lastTrainOfDay to departBy as a safe default.
             return itemChoiceType switch
             {
                 0 => "arriveBy",
                 1 => "departBy",
-                2 => "firstTrainOfDay",
-                3 => "lastTrainOfDay",
                 _ => "departBy"
             };
         }

--- a/Huxley2/Services/PostcodeJourneyPlannerService.cs
+++ b/Huxley2/Services/PostcodeJourneyPlannerService.cs
@@ -59,7 +59,7 @@ namespace Huxley2.Services
             try
             {
                 var soapXml = BuildSoapRequest(postcode, stationCrs, originIsPostcode, request);
-                _logger.LogInformation("OJP SOAP REQUEST (postcode):\n{Soap}", soapXml);
+                _logger.LogDebug("OJP SOAP REQUEST (postcode):\n{Soap}", soapXml);
 
                 var httpRequest = new HttpRequestMessage(HttpMethod.Post, _endpoint);
                 httpRequest.Content = new StringContent(soapXml, Encoding.UTF8, "text/xml");
@@ -87,7 +87,7 @@ namespace Huxley2.Services
                 }
 
                 var responseXml = await httpResponse.Content.ReadAsStringAsync();
-                _logger.LogInformation("OJP SOAP RESPONSE (postcode):\n{Soap}", responseXml);
+                _logger.LogDebug("OJP SOAP RESPONSE (postcode):\n{Soap}", responseXml);
 
                 XDocument doc;
                 try

--- a/Huxley2/Services/PostcodeJourneyPlannerService.cs
+++ b/Huxley2/Services/PostcodeJourneyPlannerService.cs
@@ -221,6 +221,10 @@ namespace Huxley2.Services
             }
 
             var timeElementName = GetTimeElementName(request.ItemChoiceType);
+
+            // The OJP PostcodeJourneyPlan endpoint treats the time as UK local time
+            // (same as the RealtimeJourneyPlan endpoint). No timezone conversion needed —
+            // the client sends UK local time and we pass it through as-is.
             var dateTimeStr = request.PlannedTime.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
             var enquiryType = request.EnquiryType == 0 ? "STANDARD" : "CHECK_ALTERNATIVES";
             var directTrains = request.DirectTrains ? "true" : "false";
@@ -363,8 +367,10 @@ namespace Huxley2.Services
             var idStr = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "id")?.Value;
             int.TryParse(idStr, out var id);
 
-            var board = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "board")?.Value ?? string.Empty;
-            var alight = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "alight")?.Value ?? string.Empty;
+            var boardEl = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "board");
+            var board = boardEl?.Elements().FirstOrDefault(e => e.Name.LocalName == "crsCode")?.Value ?? boardEl?.Value ?? string.Empty;
+            var alightEl = legEl.Elements().FirstOrDefault(e => e.Name.LocalName == "alight");
+            var alight = alightEl?.Elements().FirstOrDefault(e => e.Name.LocalName == "crsCode")?.Value ?? alightEl?.Value ?? string.Empty;
 
             var origins = legEl.Elements().Where(e => e.Name.LocalName == "origins").Select(e => e.Value).ToArray();
             var destinations = legEl.Elements().Where(e => e.Name.LocalName == "destinations").Select(e => e.Value).ToArray();

--- a/Huxley2/Startup.cs
+++ b/Huxley2/Startup.cs
@@ -129,29 +129,6 @@ namespace Huxley2
             ILogger<Startup> logger,
             IUpdateCheckService updateCheckService)
         {
-            // ✅ FIRST — absolute earliest hook into the request
-            app.Use(async (context, next) =>
-            {
-                Console.WriteLine(
-                    $"STDOUT HIT {context.Request.Method} {context.Request.Path} TraceId={context.TraceIdentifier}"
-                );
-
-                logger.LogInformation(
-                    "APPLOG HIT {Method} {Path} TraceId={TraceId}",
-                    context.Request.Method,
-                    context.Request.Path,
-                    context.TraceIdentifier
-                );
-
-                context.Response.OnStarting(() =>
-                {
-                    Console.WriteLine($"STDOUT RESP {context.Response.StatusCode} TraceId={context.TraceIdentifier}");
-                    return Task.CompletedTask;
-                });
-
-                await next();
-            });
-
             logger.LogInformation("Configuring Huxley 2 web API application");
 
             app.UseForwardedHeaders(new ForwardedHeadersOptions

--- a/Huxley2/Startup.cs
+++ b/Huxley2/Startup.cs
@@ -102,6 +102,12 @@ namespace Huxley2
             services.AddSingleton<IServiceDetailsService, ServiceDetailsService>();
             services.AddSingleton<IUpdateCheckService, UpdateCheckService>();
             services.AddSingleton<IJourneyPlannerService, JourneyPlannerService>();
+            services.AddSingleton<IPostcodeJourneyPlannerService>(sp =>
+                new PostcodeJourneyPlannerService(
+                    sp.GetRequiredService<ILoggerFactory>().CreateLogger<PostcodeJourneyPlannerService>(),
+                    sp.GetRequiredService<IStationService>(),
+                    sp.GetRequiredService<HttpClient>(),
+                    sp.GetRequiredService<IConfiguration>()));
             services.AddSingleton<INearbyStationService, NearbyStationService>();
             // Singleton HTTP client is best practice and is fine as we don't use authentication or cookies
             // No interface is available but we can mock it by passing in a fake handler to the constructor

--- a/Huxley2/Utils/PostcodeValidator.cs
+++ b/Huxley2/Utils/PostcodeValidator.cs
@@ -1,0 +1,34 @@
+using System.Text.RegularExpressions;
+
+namespace Huxley2.Utils
+{
+    public static class PostcodeValidator
+    {
+        private static readonly Regex PostcodePattern = new Regex(
+            @"^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$",
+            RegexOptions.Compiled);
+
+        /// <summary>
+        /// Normalises a postcode by trimming whitespace, removing internal spaces, and converting to uppercase.
+        /// </summary>
+        public static string NormalisePostcode(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return string.Empty;
+
+            return input.Trim().Replace(" ", "").ToUpperInvariant();
+        }
+
+        /// <summary>
+        /// Returns true if the string is a valid UK postcode after normalisation.
+        /// </summary>
+        public static bool IsValidUkPostcode(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return false;
+
+            var normalised = NormalisePostcode(input);
+            return PostcodePattern.IsMatch(normalised);
+        }
+    }
+}

--- a/Huxley2Tests/Controllers/PostcodePlannerControllerTests.cs
+++ b/Huxley2Tests/Controllers/PostcodePlannerControllerTests.cs
@@ -1,0 +1,260 @@
+// © James Singleton. EUPL-1.2 (see the LICENSE file for the full license governing this code).
+
+using FakeItEasy;
+using Huxley2.Controllers;
+using Huxley2.Exceptions;
+using Huxley2.Interfaces;
+using Huxley2.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.ServiceModel;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Huxley2Tests.Controllers
+{
+    public class PostcodePlannerControllerTests
+    {
+        private readonly IPostcodeJourneyPlannerService _service;
+        private readonly PostcodePlannerController _controller;
+
+        public PostcodePlannerControllerTests()
+        {
+            _service = A.Fake<IPostcodeJourneyPlannerService>();
+            _controller = new PostcodePlannerController(
+                A.Fake<ILogger<PostcodePlannerController>>(),
+                _service);
+            _controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+        }
+
+        [Fact]
+        public async Task Get_WithPostcodeOriginAndCrsDestination_ReturnsOk()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            var expected = new PostcodeJourneyPlanResponseModel
+            {
+                GeneratedAt = DateTime.UtcNow,
+                Postcode = "SW1A 1AA",
+                StationCrs = "PAD"
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                request, "SW1A 1AA", "PAD", true))
+                .Returns(expected);
+
+            var result = await _controller.Get(request);
+
+            Assert.IsType<OkObjectResult>(result.Result);
+            var ok = (OkObjectResult)result.Result;
+            Assert.Equal(expected, ok.Value);
+        }
+
+        [Fact]
+        public async Task Get_WithCrsOriginAndPostcodeDestination_ReturnsOk()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "WAT",
+                Destination = "RH6 0NN",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            var expected = new PostcodeJourneyPlanResponseModel
+            {
+                GeneratedAt = DateTime.UtcNow,
+                Postcode = "RH6 0NN",
+                StationCrs = "WAT"
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                request, "RH6 0NN", "WAT", false))
+                .Returns(expected);
+
+            var result = await _controller.Get(request);
+
+            Assert.IsType<OkObjectResult>(result.Result);
+        }
+
+        [Fact]
+        public async Task Get_BothCrs_ReturnsBadRequest_UseStandardPlanner()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "WAT",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+
+            var result = await _controller.Get(request);
+
+            Assert.IsType<BadRequestObjectResult>(result.Result);
+            var error = (ApiError)((BadRequestObjectResult)result.Result).Value;
+            Assert.Equal("USE_STANDARD_PLANNER", error.Code);
+        }
+
+        [Fact]
+        public async Task Get_BothNonCrs_ReturnsBadRequest_PostcodeNotAllowedForBoth()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "EC1M 6BY",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+
+            var result = await _controller.Get(request);
+
+            Assert.IsType<BadRequestObjectResult>(result.Result);
+            var error = (ApiError)((BadRequestObjectResult)result.Result).Value;
+            Assert.Equal("POSTCODE_NOT_ALLOWED_FOR_BOTH", error.Code);
+        }
+
+        [Fact]
+        public async Task Get_InvalidPostcodeFormat_ReturnsBadRequest()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "NOTAPOSTCODE",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+
+            var result = await _controller.Get(request);
+
+            Assert.IsType<BadRequestObjectResult>(result.Result);
+            var error = (ApiError)((BadRequestObjectResult)result.Result).Value;
+            Assert.Equal("INVALID_POSTCODE_FORMAT", error.Code);
+        }
+
+        [Fact]
+        public async Task Get_ServiceReturnsNull_Returns502()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                A<PostcodeJourneyPlannerRequest>._, A<string>._, A<string>._, A<bool>._))
+                .Returns((PostcodeJourneyPlanResponseModel)null);
+
+            var result = await _controller.Get(request);
+
+            var statusResult = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(502, statusResult.StatusCode);
+            var error = (ApiError)statusResult.Value;
+            Assert.Equal("OJP_EMPTY_RESPONSE", error.Code);
+        }
+
+        [Fact]
+        public async Task Get_OjpFaultNoJourneysFound_Returns404()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                A<PostcodeJourneyPlannerRequest>._, A<string>._, A<string>._, A<bool>._))
+                .ThrowsAsync(new OjpFaultException("PostcodeJourneyPlan", "NoJourneysFound", "No journeys available"));
+
+            var result = await _controller.Get(request);
+
+            var statusResult = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(404, statusResult.StatusCode);
+            var error = (ApiError)statusResult.Value;
+            Assert.Equal("NoJourneysFound", error.Code);
+        }
+
+        [Fact]
+        public async Task Get_OjpFaultDateInPast_Returns400()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                A<PostcodeJourneyPlannerRequest>._, A<string>._, A<string>._, A<bool>._))
+                .ThrowsAsync(new OjpFaultException("PostcodeJourneyPlan", "OutwardDateTimeInThePast", null));
+
+            var result = await _controller.Get(request);
+
+            var statusResult = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(400, statusResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task Get_TimeoutException_Returns504()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                A<PostcodeJourneyPlannerRequest>._, A<string>._, A<string>._, A<bool>._))
+                .ThrowsAsync(new TimeoutException("timed out"));
+
+            var result = await _controller.Get(request);
+
+            var statusResult = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(504, statusResult.StatusCode);
+            var error = (ApiError)statusResult.Value;
+            Assert.Equal("OJP_TIMEOUT", error.Code);
+        }
+
+        [Fact]
+        public async Task Get_CommunicationException_Returns502()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                A<PostcodeJourneyPlannerRequest>._, A<string>._, A<string>._, A<bool>._))
+                .ThrowsAsync(new CommunicationException("connection failed"));
+
+            var result = await _controller.Get(request);
+
+            var statusResult = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(502, statusResult.StatusCode);
+            var error = (ApiError)statusResult.Value;
+            Assert.Equal("OJP_UPSTREAM_COMMUNICATION", error.Code);
+        }
+
+        [Fact]
+        public async Task Get_OjpUpstreamException_Returns502()
+        {
+            var request = new PostcodeJourneyPlannerRequest
+            {
+                Origin = "SW1A 1AA",
+                Destination = "PAD",
+                PlannedTime = DateTime.UtcNow.AddHours(1)
+            };
+            A.CallTo(() => _service.GetPostcodeJourneyPlanAsync(
+                A<PostcodeJourneyPlannerRequest>._, A<string>._, A<string>._, A<bool>._))
+                .ThrowsAsync(new OjpUpstreamException("bad XML"));
+
+            var result = await _controller.Get(request);
+
+            var statusResult = Assert.IsType<ObjectResult>(result.Result);
+            Assert.Equal(502, statusResult.StatusCode);
+            var error = (ApiError)statusResult.Value;
+            Assert.Equal("OJP_UPSTREAM_ERROR", error.Code);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new postcode-based journey planning API to Huxley2, allowing callers to plan journeys between a UK postcode and a station CRS via the NRE OJP SOAP endpoint.

Changes:

Introduces GET /api/planner/postcode with request/response models and a postcode validator.
Adds a new PostcodeJourneyPlannerService to call OJP PostcodeJourneyPlan and parse SOAP XML into existing journey models.
Updates site documentation/navigation and extends SOAP fault capture for postcode faults.
